### PR TITLE
Update README.md: use go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Some may think that I have too much faith in pure Go, but this is my honest feel
 
 # Installation
 
-(go get):
+(go install): 
 
 ```
+go install github.com/kyoh86/richgo@latest
+# or for older go versions
 go get -u github.com/kyoh86/richgo
 ```
 


### PR DESCRIPTION
use go install to install binary (since go ~ 1.17 supported)