### PR TITLE
Fix broke link for release badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rich-Go will enrich `go test` outputs with text decorations
 [![PkgGoDev](https://pkg.go.dev/badge/kyoh86/richgo)](https://pkg.go.dev/kyoh86/richgo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kyoh86/richgo)](https://goreportcard.com/report/github.com/kyoh86/richgo)
 [![Coverage Status](https://img.shields.io/codecov/c/github/kyoh86/richgo.svg)](https://codecov.io/gh/kyoh86/richgo)
-[![Release](https://github.com/kyoh86/richgo/workflows/Release/badge.svg)](https://github.com/kyoh86/richgo/releases)
+[![Release](https://img.shields.io/github/v/release/kyoh86/richgo?style=flat-square)](https://github.com/kyoh86/richgo/releases)
 
 [![asciicast](https://asciinema.org/a/99810.png)](https://asciinema.org/a/99810)
 


### PR DESCRIPTION
The link of release badge in README.md seems broken.

<img width="921" alt="image" src="https://github.com/user-attachments/assets/2ba82d90-d155-4404-8166-c6f44e90320f">



If the badge I added is not the thing you want to display, please point out.